### PR TITLE
Add detail modal when clicking a repository row

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,14 @@ const elements = {
     fieldFilter: document.getElementById('field-filter'),
     completenessFilter: document.getElementById('completeness-filter'),
     archiveFilter: document.getElementById('archive-filter'),
-    columnCheckboxes: document.getElementById('column-checkboxes')
+    columnCheckboxes: document.getElementById('column-checkboxes'),
+
+      // Modal
+        detailModal: document.getElementById('detail-modal'),
+        modalOverlay: document.getElementById('modal-overlay'),
+        modalClose: document.getElementById('modal-close'),
+        modalTitle: document.getElementById('modal-title'),
+        modalBody: document.getElementById('modal-body'),
 };
 
 // Application State
@@ -133,6 +140,15 @@ function setupEventListeners() {
     // Export
     elements.exportBtn.addEventListener('click', exportToCSV);
 }
+
+ // Modal
+    elements.modalClose.addEventListener('click', closeDetailModal);
+    elements.modalOverlay.addEventListener('click', closeDetailModal);
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !elements.detailModal.hidden) {
+            closeDetailModal();
+        }
+    });
 
 function updateStatus(message) {
     elements.status.textContent = message;
@@ -355,6 +371,15 @@ function renderTableBody(data) {
             }).join('')}
         </tr>
     `).join('');
+
+     // Row click opens detail modal
+    const rows = elements.tableBody.querySelectorAll('tr');
+    rows.forEach((tr, index) => {
+        tr.style.cursor = 'pointer';
+        tr.addEventListener('click', () => {
+            openDetailModal(data[index]);
+        });
+    });
 }
 
 function getVisibleColumns() {
@@ -482,6 +507,38 @@ function togglePanel(panel) {
             p.classList.add('hidden');
         }
     });
+}
+
+function openDetailModal(row) {
+    if (!row) return;
+    const title = row.repo || 'Repository';
+    elements.modalTitle.textContent = title;
+
+    const html = state.columns
+        .filter(col => col !== 'archived')
+        .map(col => {
+            const value = row[col];
+            const label = formatColumnName(col);
+            let display = '—';
+            if (hasData(value)) {
+                const str = String(value).trim();
+                if (str.startsWith('http://') || str.startsWith('https://')) {
+                    display = `<a href="${escapeHtml(str)}" target="_blank" rel="noopener">${escapeHtml(str)}</a>`;
+                } else {
+                    display = escapeHtml(str.length > 200 ? str.substring(0, 200) + '...' : str);
+                }
+            }
+            return `<dt>${label}</dt><dd>${display}</dd>`;
+
+              })
+        .join('');
+
+    elements.modalBody.innerHTML = html ? `<dl>${html}</dl>` : '<p>No metadata.</p>';
+    elements.detailModal.hidden = false;
+}
+
+function closeDetailModal() {
+    elements.detailModal.hidden = true;
 }
 
 function toggleTheme() {

--- a/index.html
+++ b/index.html
@@ -111,6 +111,19 @@
     <div class="status" id="status">Loading data...</div>
   </footer>
 
+   <!-- Project detail modal -->
+    <div id="detail-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+      <div class="modal-overlay" id="modal-overlay"></div>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 id="modal-title" class="modal-title">Repository details</h2>
+          <button type="button" class="modal-close" id="modal-close" aria-label="Close">×</button>
+        </div>
+        <div class="modal-body" id="modal-body">
+        </div>
+      </div>
+    </div>
+
   <script src="app.js"></script>
 </body>
 

--- a/styles.css
+++ b/styles.css
@@ -518,3 +518,94 @@ tbody tr:last-child td {
     max-width: 150px;
   }
 }
+
+
+/* ===== MODAL ===== */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-md);
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+}
+
+.modal-content {
+  position: relative;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  max-width: 600px;
+  width: 100%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-title {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--text-light);
+  padding: 0 var(--space-sm);
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: var(--text);
+}
+
+.modal-body {
+  padding: var(--space-lg);
+  overflow-y: auto;
+}
+
+.modal-body dl {
+  margin: 0;
+}
+
+.modal-body dt {
+  font-weight: 600;
+  color: var(--text-light);
+  margin-top: var(--space-sm);
+}
+
+.modal-body dt:first-child {
+  margin-top: 0;
+}
+
+.modal-body dd {
+  margin: var(--space-xs) 0 0 var(--space-sm);
+  word-break: break-word;
+}
+
+modal-body dd a {
+  color: var(--primary);
+}

--- a/styles.css
+++ b/styles.css
@@ -606,6 +606,6 @@ tbody tr:last-child td {
   word-break: break-word;
 }
 
-modal-body dd a {
+.modal-body dd a {
   color: var(--primary);
 }


### PR DESCRIPTION
Table rows only show a subset of fields. There was no way to see a repo’s full metadata without exporting.

This adds a modal that opens when you click a row: it shows all metadata for that repository in one place. You can close it with the × button, by clicking outside, or with Escape. Implements Task #31 from TASKS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table rows are interactive—click a row to open a detail modal showing title and metadata.
  * Modal supports multiple close actions: close button, overlay click, and Escape key.
  * Modal content is dynamically constructed and safely truncated/escaped for display.

* **Style**
  * Added complete modal styling (overlay, centered content, header, close control, body with scrolling and responsive behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->