### PR TITLE
Add FAQ section to the explorer

### DIFF
--- a/app.js
+++ b/app.js
@@ -532,7 +532,7 @@ function openDetailModal(row) {
         .filter(col => col !== 'archived')
         .map(col => {
             const value = row[col];
-            const label = formatColumnName(col);
+            const label = escapeHtml(formatColumnName(col));
             let display = '—';
             if (hasData(value)) {
                 const str = String(value).trim();

--- a/app.js
+++ b/app.js
@@ -26,7 +26,18 @@ const elements = {
     fieldFilter: document.getElementById('field-filter'),
     completenessFilter: document.getElementById('completeness-filter'),
     archiveFilter: document.getElementById('archive-filter'),
-    columnCheckboxes: document.getElementById('column-checkboxes')
+    columnCheckboxes: document.getElementById('column-checkboxes'),
+
+    // Modal
+    detailModal: document.getElementById('detail-modal'),
+    modalOverlay: document.getElementById('modal-overlay'),
+    modalClose: document.getElementById('modal-close'),
+    modalTitle: document.getElementById('modal-title'),
+    modalBody: document.getElementById('modal-body'),
+
+    // FAQ
+    faqToggle: document.getElementById('faq-toggle'),
+    faqList: document.getElementById('faq-list'),
 };
 
 // Application State
@@ -132,6 +143,25 @@ function setupEventListeners() {
     
     // Export
     elements.exportBtn.addEventListener('click', exportToCSV);
+
+    // Modal (only if modal exists in the page)
+    if (elements.modalClose && elements.modalOverlay && elements.detailModal) {
+        elements.modalClose.addEventListener('click', closeDetailModal);
+        elements.modalOverlay.addEventListener('click', closeDetailModal);
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && !elements.detailModal.hidden) {
+                closeDetailModal();
+            }
+        });
+    }
+
+    // FAQ toggle
+    if (elements.faqToggle && elements.faqList) {
+        elements.faqToggle.addEventListener('click', () => {
+            const isOpen = elements.faqList.classList.toggle('hidden');
+            elements.faqToggle.setAttribute('aria-expanded', !isOpen);
+        });
+    }
 }
 
 function updateStatus(message) {
@@ -355,6 +385,15 @@ function renderTableBody(data) {
             }).join('')}
         </tr>
     `).join('');
+
+    // Row click opens detail modal
+    const rows = elements.tableBody.querySelectorAll('tr');
+    rows.forEach((tr, index) => {
+        tr.style.cursor = 'pointer';
+        tr.addEventListener('click', () => {
+            openDetailModal(data[index]);
+        });
+    });
 }
 
 function getVisibleColumns() {
@@ -482,6 +521,37 @@ function togglePanel(panel) {
             p.classList.add('hidden');
         }
     });
+}
+
+function openDetailModal(row) {
+    if (!row) return;
+    const title = row.repo || 'Repository';
+    elements.modalTitle.textContent = title;
+
+    const html = state.columns
+        .filter(col => col !== 'archived')
+        .map(col => {
+            const value = row[col];
+            const label = formatColumnName(col);
+            let display = '—';
+            if (hasData(value)) {
+                const str = String(value).trim();
+                if (str.startsWith('http://') || str.startsWith('https://')) {
+                    display = `<a href="${escapeHtml(str)}" target="_blank" rel="noopener">${escapeHtml(str)}</a>`;
+                } else {
+                    display = escapeHtml(str.length > 200 ? str.substring(0, 200) + '...' : str);
+                }
+            }
+            return `<dt>${label}</dt><dd>${display}</dd>`;
+        })
+        .join('');
+
+    elements.modalBody.innerHTML = html ? `<dl>${html}</dl>` : '<p>No metadata.</p>';
+    elements.detailModal.hidden = false;
+}
+
+function closeDetailModal() {
+    elements.detailModal.hidden = true;
 }
 
 function toggleTheme() {

--- a/index.html
+++ b/index.html
@@ -106,6 +106,25 @@
     </div>
   </main>
 
+  <!-- FAQ section -->
+  <section class="faq-section" id="faq-section">
+    <button type="button" class="faq-toggle" id="faq-toggle" aria-expanded="false" aria-controls="faq-list">
+      Frequently asked questions
+    </button>
+    <div class="faq-list hidden" id="faq-list" role="region" aria-label="FAQ">
+      <dl class="faq-dl">
+        <dt>Where does the data come from?</dt>
+        <dd>Metadata is scraped from OWASP organization repositories on GitHub. Each repo’s <code>index.md</code> (Jekyll front matter) is read and normalized into the table.</dd>
+        <dt>Why does it say "Failed to load metadata"?</dt>
+        <dd>Opening the page via <code>file://</code> can block loading the data file. Use a local server instead, e.g. <code>python -m http.server 8000</code>, then open <code>http://localhost:8000</code>.</dd>
+        <dt>How do I see all fields for a repository?</dt>
+        <dd>Click a row in the table. A modal opens with the full metadata for that repository.</dd>
+        <dt>How often is the data updated?</dt>
+        <dd>Data is refreshed by the project’s GitHub Actions workflow (see the scraper workflow in the repo). You can also run the scraper locally with <code>python scripts/scrape_metadata.py</code>.</dd>
+      </dl>
+    </div>
+  </section>
+
   <!-- status -->
   <footer class="footer">
     <div class="status" id="status">Loading data...</div>

--- a/styles.css
+++ b/styles.css
@@ -518,3 +518,69 @@ tbody tr:last-child td {
     max-width: 150px;
   }
 }
+
+/* ===== FAQ SECTION ===== */
+.faq-section {
+  padding: var(--space-md) var(--space-xl);
+  border-top: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.faq-toggle {
+  background: none;
+  border: none;
+  font: inherit;
+  color: var(--primary);
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.faq-toggle:hover {
+  color: var(--primary-dark);
+}
+
+.faq-toggle[aria-expanded="true"]::before {
+  content: "▼ ";
+  font-size: 0.75em;
+}
+
+.faq-toggle[aria-expanded="false"]::before {
+  content: "▶ ";
+  font-size: 0.75em;
+}
+
+.faq-list.hidden {
+  display: none;
+}
+
+.faq-list {
+  margin-top: var(--space-md);
+  max-width: 50rem;
+}
+
+.faq-dl {
+  margin: 0;
+}
+
+.faq-dl dt {
+  font-weight: 600;
+  margin-top: var(--space-md);
+  color: var(--text);
+}
+
+.faq-dl dt:first-child {
+  margin-top: 0;
+}
+
+.faq-dl dd {
+  margin: var(--space-xs) 0 0 var(--space-sm);
+  color: var(--text-light);
+}
+
+.faq-dl code {
+  background: var(--bg-tertiary);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}


### PR DESCRIPTION
New users often ask where the data comes from and why the page shows "Failed to load metadata" when opened from disk. This adds a collapsible FAQ above the footer with short answers on data source, using a local server, the row-click detail modal, and how often data is updated. Implements Task #80 from TASKS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expandable FAQ section with answers about data sources, failures, viewing full fields, and update frequency.
  * Enabled detail modal viewing — click any table row to open a detailed view; modal shows item title and field details.
  * Enhanced modal interaction — close by clicking overlay, close button, or pressing Escape.
  * Improved table sorting accessibility via header-based sorting.

* **Style**
  * Added FAQ styling and visibility behaviors for the new FAQ component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->