### PR TITLE
fix: resolve last updated loading issue caused by tags type error

### DIFF
--- a/mermaid-diagram.js
+++ b/mermaid-diagram.js
@@ -103,7 +103,7 @@ async function loadData() {
             title: item.title,
             type: (item.type || '').toLowerCase(),
             level: item.level || 0,
-            tags: (item.tags || '').toLowerCase(),
+            tags: (Array.isArray(item.tags) ? item.tags.join(", "): (item.tags || '')).toLowerCase(),
             pitch: item.pitch || ''
         }));
         

--- a/mermaid-diagram.js
+++ b/mermaid-diagram.js
@@ -103,7 +103,15 @@ async function loadData() {
             title: item.title,
             type: (item.type || '').toLowerCase(),
             level: item.level || 0,
-            tags: (Array.isArray(item.tags) ? item.tags.join(", "): (item.tags || '')).toLowerCase(),
+            tags: (
+                Array.isArray(item.tags)
+                ? item.tags.join(", ")
+                : typeof item.tags === "string"
+                ? item.tags
+                : item.tags != null
+                ? String(item.tags)
+                : ""
+            ).toLowerCase(),
             pitch: item.pitch || ''
         }));
         


### PR DESCRIPTION
## Description
This PR fixes the issue where the "Last Updated" field in the footer remained stuck on "Loading..." on SDLC Diagram page.

## Root Cause
A JavaScript error was occurring due to improper handling of `item.tags`, where `.toLowerCase()` was being called on a non-string value (e.g., array). This caused script execution to stop, preventing the footer timestamp from updating.

## Fix
-Added proper handling for `item.tags` to support both string and array types
-Ensured safe conversion before applying `.toLowerCase()`

## Changes Made
-Updated tags handling logic in `mermaid-diagram.js`

## Result
-Footer now correctly displays the "Last Updated" timestamp

## Screenshots
<img width="716" height="458" alt="image" src="https://github.com/user-attachments/assets/f144f91c-e3f7-4581-80be-5d4160502174" />


Fixes #23 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag normalization to accept arrays or strings and consistently produce a lowercase, comma-separated tag string.
  * Ensures empty or missing tag values are handled gracefully, avoiding unexpected displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->